### PR TITLE
Always draw images before the number in numbers game

### DIFF
--- a/numbers_game.py
+++ b/numbers_game.py
@@ -113,6 +113,6 @@ class Numbers:
 
     def draw(self):
         self.screen.fill(pg.color.Color("gray98"))
-        self.number_char.draw(self.screen)
         for img in self.image_buffer:
             img.draw(self.screen)
+        self.number_char.draw(self.screen)


### PR DESCRIPTION
Drawing the images first guarantees that the number is always visible