### PR TITLE
Replace os.path.join with pathlib.Path to fix paths for non-Windows systems

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import pygame as pg
 import sys
-import os
 import json
+from pathlib import Path
 from letters_game import Letters
 from numbers_game import Numbers
 from balloons_game import Balloons
@@ -16,7 +16,7 @@ class Exit:
 
 class MainMenuBG:
     def __init__(self):
-        self.image = pg.image.load(os.path.join("images", "BabySmashBG_static.png"))
+        self.image = pg.image.load(Path.cwd() / "images" / "BabySmashBG_static.png")
         self.rect = pg.Rect(0, 0, 1920, 1080)
 
     def draw(self, screen):
@@ -177,7 +177,7 @@ class Application:
         self.current_state = self.base_state
 
     def set_icon_and_window_title(self):
-        icon = pg.image.load(os.path.join("images", "BabySmashIcon.png"))
+        icon = pg.image.load(Path.cwd() / "images" / "BabySmashIcon.png")
         pg.display.set_icon(icon)
         pg.display.set_caption("BabySmash")
 

--- a/balloons_game.py
+++ b/balloons_game.py
@@ -1,6 +1,6 @@
 import pygame as pg
-import os
 import random
+from pathlib import Path
 from pygame.locals import KEYDOWN
 
 from utils import rand_screen_pos
@@ -45,7 +45,7 @@ class InGameBallon:
     def __init__(self, char="", size=500, pos=(0, 0), color="blue"):
         self.char = char
         self.rect = pg.Rect(pos, (size, size))
-        path = os.path.join("images\\balloon", f"balloon_{color}.png")
+        path = Path.cwd() / "images" / "balloon" / f"balloon_{color}.png"
         self.char_surf = get_balloon_char(char, size//4)
         self.char_rect = pg.Rect(pos, self.char_surf.get_size())
         self.pop_imgs = load_balloon_sprites(path, size)
@@ -95,7 +95,7 @@ class Balloons:
         self.config = config
         num = random.randint(self.config['min_balloons'], self.config['max_balloons'])
         self.balloons = self.generate_balloons(num)
-        path = os.path.join("sounds\\balloon", "balloon-pop.wav")
+        path = Path.cwd() / "sounds" / "balloon" / "balloon-pop.wav"
         self.pop_sound = pg.mixer.Sound(path)
 
     @property

--- a/numbers_game.py
+++ b/numbers_game.py
@@ -1,6 +1,6 @@
 import pygame as pg
 from pygame.locals import KEYDOWN
-import os
+from pathlib import Path
 from random import randint, uniform, choice
 from character import Character
 from utils import rand_screen_pos
@@ -77,10 +77,7 @@ class Numbers:
                         pos,
                         size,
                         self.rotate_angle,
-                        os.path.join(
-                            "images",
-                            choice(["ladybug.png", "butterfly.png", "snail.png"]),
-                        ),
+                        Path.cwd() / "images" / choice(["ladybug.png", "butterfly.png", "snail.png"])
                     )
                     self.image_buffer.append(lady)
                     break


### PR DESCRIPTION
I attempted to play the balloon game on my Mac and got this error: 
```python
Traceback (most recent call last):
  File "app.py", line 220, in <module>
    application.loop()
  File "app.py", line 211, in loop
    self.current_state.update()
  File "app.py", line 142, in update
    self.handle_events()
  File "app.py", line 137, in handle_events
    self.switch_state(self.items[self.sel_idx].state)
  File "app.py", line 197, in switch_state
    self.current_state = Balloons(
  File "/Users/huymai/Hacktoberfest/BabySmash/BabySmash/balloons_game.py", line 97, in __init__
    self.balloons = self.generate_balloons(num)
  File "/Users/huymai/Hacktoberfest/BabySmash/BabySmash/balloons_game.py", line 115, in generate_balloons
    ba = self.new_balloon(letters[i])
  File "/Users/huymai/Hacktoberfest/BabySmash/BabySmash/balloons_game.py", line 109, in new_balloon
    return InGameBallon(char, size, pos, color)
  File "/Users/huymai/Hacktoberfest/BabySmash/BabySmash/balloons_game.py", line 51, in __init__
    self.pop_imgs = load_balloon_sprites(path, size)
  File "/Users/huymai/Hacktoberfest/BabySmash/BabySmash/balloons_game.py", line 29, in load_balloon_sprites
    sheet = pg.image.load(filename).convert_alpha()
FileNotFoundError: No file 'images\balloon/balloon_lightyellow.png' found in working directory '/Users/huymai/Hacktoberfest/BabySmash/BabySmash'.
```

I found that the code for the paths was written for Windows systems with the `\` for file paths and did not account for non-Windows systems. I replaced code containing `os.path.join` with `pathlib.Path` to fix paths for non-Windows systems to make the games run.