### PR TITLE
Ballon-game: platform-independent path-usage

### DIFF
--- a/baby_config.json
+++ b/baby_config.json
@@ -18,7 +18,7 @@
             256,
             1024
         ],
-        "alphabet": "ABCDEFGHIJKLMNOPRSTUVWXYZÆØÅ",
+        "alphabet": "ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅ",
         "max_balloons": 7,
         "min_balloons": 3
     }

--- a/balloons_game.py
+++ b/balloons_game.py
@@ -45,7 +45,7 @@ class InGameBallon:
     def __init__(self, char="", size=500, pos=(0, 0), color="blue"):
         self.char = char
         self.rect = pg.Rect(pos, (size, size))
-        path = os.path.join("images\\balloon", f"balloon_{color}.png")
+        path = os.path.join("images","balloon", f"balloon_{color}.png")
         self.char_surf = get_balloon_char(char, size//4)
         self.char_rect = pg.Rect(pos, self.char_surf.get_size())
         self.pop_imgs = load_balloon_sprites(path, size)
@@ -95,7 +95,7 @@ class Balloons:
         self.config = config
         num = random.randint(self.config['min_balloons'], self.config['max_balloons'])
         self.balloons = self.generate_balloons(num)
-        path = os.path.join("sounds\\balloon", "balloon-pop.wav")
+        path = os.path.join("sounds","balloon", "balloon-pop.wav")
         self.pop_sound = pg.mixer.Sound(path)
 
     @property
@@ -131,7 +131,7 @@ class Balloons:
                 if key_str == "" or key_str not in self.config['alphabet']:
                     pass
                 # Do balloons
-                if key_str == "Q":
+                if key_str == "ESCAPE":
                     self.quit()
                 for balloon in self.balloons:
                     if key_str == balloon.char:


### PR DESCRIPTION
os.path.join can facilitate platform-independent path-usage if you give it a chance.

Also, change quit-keybinding to escape to allow Q to be used for ballons.